### PR TITLE
Fix for heroku config:push

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ Remember to grab the address of the app in this point
 ## Setting the allowed hosts
 * include your address at the ALLOWED_HOSTS directives in settings.py - Just the domain, make sure that you will take the protocol and slashes from the string
 
+## Heroku install config plugin
+* heroku plugins:install heroku-config
+
 ### Sending configs from .env to Heroku ( You have to be inside tha folther where .env files is)
-* heroku config:push
+* heroku config:push -a
 
 ### To show heroku configs do
 * heroku config 


### PR DESCRIPTION
Heroku configs plugin is required for pushing configs. Also - a [appname] is required on the first time pushing the configs